### PR TITLE
feat: Add C++, Node.js, Rust templates and Korean README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,203 @@
+# Nix Flake 템플릿
+
+<!--toc:start-->
+- [Nix Flake 템플릿](#nix-flake-템플릿)
+  - [템플릿 목록](#템플릿-목록)
+  - [`trivial` &mdash; 기본 Nix Flake 템플릿](#trivial-mdash-기본-nix-flake-템플릿)
+  - [`python-script` &mdash; Python 프로그램 스크립트 템플릿](#python-script-mdash-python-프로그램-스크립트-템플릿)
+  - [`python-package` &mdash; Python 패키지 템플릿](#python-package-mdash-python-패키지-템플릿)
+  - [`haskell-simple-app` &mdash; 간단한 Haskell 애플리케이션](#haskell-simple-app-mdash-간단한-haskell-애플리케이션)
+  - [`cpp-cmake-project` &mdash; C++/CMake 프로젝트 템플릿](#cpp-cmake-project-mdash-ccmake-프로젝트-템플릿)
+  - [`nodejs-app` &mdash; Node.js 애플리케이션 템플릿](#nodejs-app-mdash-nodejs-애플리케이션-템플릿)
+  - [`rust-app` &mdash; Rust 애플리케이션 템플릿](#rust-app-mdash-rust-애플리케이션-템플릿)
+<!--toc:end-->
+
+## 템플릿 목록
+
+```sh
+nix flake show github:vst/nix-flake-templates
+```
+
+## `trivial` &mdash; 기본 Nix Flake 템플릿
+
+이 템플릿은 특별한 작업을 수행하지 않습니다. [flake-utils]를 사용하여 여러 대상 시스템을 위한 Nix Flake를 만드는 방법을 보여줍니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#trivial
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/trivial" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/trivial
+```
+
+## `python-script` &mdash; Python 프로그램 스크립트 템플릿
+
+이 템플릿은 Python 스크립트를 Nix Flake 출력으로 실행 가능한 프로그램으로 변환합니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#python-script
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/python-script" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/python-script
+```
+
+## `python-package` &mdash; Python 패키지 템플릿
+
+이 템플릿은 다음과 같은 유용한 기능을 포함하는 Python 패키지를 제공합니다:
+
+1. 패키지 메타데이터를 위한 `pyproject.toml`
+1. 패키지 빌드를 위한 `setuptools`
+1. 테스트 실행을 위한 `nox`
+1. Python 코드 린팅 및 포맷팅을 위한 `ruff`
+1. 타입 검사를 위한 `mypy`
+1. 단위 테스트를 위한 `pytest`
+1. TOML 파일 린팅 및 포맷팅을 위한 `taplo`
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#python-package
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/python-package" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/python-package
+```
+
+> [!NOTE]
+>
+> Nix 환경이 아닌 환경에서 패키지를 테스트하여 예상대로 작동하는지 확인하는 것이 좋습니다.
+>
+> ```console
+> $ docker run --rm -it debian:12.10 bash
+> $ apt update
+> $ apt install -y curl git python3 python3-pip python3-venv vim
+> $ curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz |
+>       gzip -d - |
+>       install -m 755 /dev/stdin /usr/local/bin/taplo
+> $ mkdir -p /tmp/test && cd /tmp/test
+> $ git clone https://github.com/vst/nix-flake-templates.git
+> $ cd nix-flake-templates/templates/python-package
+> $ python3 -m venv .venv
+> $ source .venv/bin/activate
+> $ pip install --upgrade pip
+> $ pip install -e .[test]
+> $ nox
+> $ zamazingo --name=there --count=3
+> ```
+
+## `haskell-simple-app` &mdash; 간단한 Haskell 애플리케이션
+
+이 템플릿은 단일 Haskell 파일 Main.hs와 `.cabal` 파일로 구성된 매우 간단한 Haskell 애플리케이션 설정을 제공합니다. 개발 환경에는 애플리케이션 작업을 편안하게 수행하는 데 필요한 모든 종속성이 포함됩니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#haskell-simple-app
+```
+
+## `cpp-cmake-project` &mdash; C++/CMake 프로젝트 템플릿
+
+이 템플릿은 CMake를 사용하는 C++ 프로젝트를 위한 기본 설정을 제공합니다. 간단한
+`main.cpp`, `CMakeLists.txt` 및 `cmake`와 C++ 컴파일러를 사용하여 개발 환경을
+설정하는 `flake.nix`가 포함되어 있습니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#cpp-cmake-project
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/cpp-cmake-project" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/cpp-cmake-project
+```
+
+## `nodejs-app` &mdash; Node.js 애플리케이션 템플릿
+
+이 템플릿은 간단한 Node.js 애플리케이션을 설정합니다. `package.json`,
+`index.js` 스크립트 및 Node.js와 npm으로 개발 환경을 제공하는 `flake.nix`가
+포함되어 있습니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#nodejs-app
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/nodejs-app" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/nodejs-app
+```
+
+## `rust-app` &mdash; Rust 애플리케이션 템플릿
+
+이 템플릿은 Cargo 및 Nix 통합을 위한 [crane]을 사용하는 Rust 애플리케이션을 위한
+기본 설정을 제공합니다. `src/main.rs`, `Cargo.toml` 및 Rust 툴체인,
+`rust-analyzer`로 개발 환경을 구성하고 `crane`을 사용하여 패키지를 빌드하는
+`flake.nix`가 포함되어 있습니다.
+
+템플릿 사용:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#rust-app
+```
+
+리포지토리를 체크아웃하지 않고 Nix Flake에 정의된 기본 패키지를 실행할 수 있습니다:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/rust-app" --no-write-lock-file
+```
+
+이 리포지토리를 체크아웃한 경우:
+
+```sh
+nix run ./templates/rust-app
+```
+
+<!-- REFERENCE -->
+
+[flake-utils]: https://github.com/numtide/flake-utils
+[crane]: https://github.com/ipetkov/crane

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   - [`python-script` &mdash; A Python Program Script Template](#python-script-mdash-a-python-program-script-template)
   - [`python-package` &mdash; A Python Package Template](#python-package-mdash-a-python-package-template)
   - [`haskell-simple-app` &mdash; A Simple Haskell Application](#haskell-simple-app-mdash-a-simple-haskell-application)
+  - [`cpp-cmake-project` &mdash; A C++/CMake Project Template](#cpp-cmake-project-mdash-a-ccmake-project-template)
+  - [`nodejs-app` &mdash; A Node.js Application Template](#nodejs-app-mdash-a-nodejs-application-template)
+  - [`rust-app` &mdash; A Rust Application Template](#rust-app-mdash-a-rust-application-template)
 <!--toc:end-->
 
 ## List of Templates
@@ -129,6 +132,83 @@ Use the template:
 nix flake init --template github:vst/nix-flake-templates#haskell-simple-app
 ```
 
+## `cpp-cmake-project` &mdash; A C++/CMake Project Template
+
+This template provides a basic setup for a C++ project using CMake. It includes a
+simple `main.cpp`, a `CMakeLists.txt`, and a `flake.nix` that sets up a
+development environment with `cmake` and a C++ compiler.
+
+Use the template:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#cpp-cmake-project
+```
+
+You can run the default package defined in the Nix Flake without checking out
+the repository:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/cpp-cmake-project" --no-write-lock-file
+```
+
+If you have checked out this repository, then:
+
+```sh
+nix run ./templates/cpp-cmake-project
+```
+
+## `nodejs-app` &mdash; A Node.js Application Template
+
+This template sets up a simple Node.js application. It includes a `package.json`,
+an `index.js` script, and a `flake.nix` providing a development environment
+with Node.js and npm.
+
+Use the template:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#nodejs-app
+```
+
+You can run the default package defined in the Nix Flake without checking out
+the repository:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/nodejs-app" --no-write-lock-file
+```
+
+If you have checked out this repository, then:
+
+```sh
+nix run ./templates/nodejs-app
+```
+
+## `rust-app` &mdash; A Rust Application Template
+
+This template provides a basic setup for a Rust application using Cargo and
+[crane] for Nix integration. It includes a `src/main.rs`, a `Cargo.toml`, and a
+`flake.nix` that configures a development environment with the Rust toolchain,
+`rust-analyzer`, and builds the package using `crane`.
+
+Use the template:
+
+```sh
+nix flake init --template github:vst/nix-flake-templates#rust-app
+```
+
+You can run the default package defined in the Nix Flake without checking out
+the repository:
+
+```sh
+nix run "github:vst/nix-flake-templates?dir=templates/rust-app" --no-write-lock-file
+```
+
+If you have checked out this repository, then:
+
+```sh
+nix run ./templates/rust-app
+```
+
 <!-- REFERENCE -->
 
 [flake-utils]: https://github.com/numtide/flake-utils
+[crane]: https://github.com/ipetkov/crane

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,21 @@
         description = "A simple Haskell application template.";
       };
 
+      cpp-cmake-project = {
+        path = ./templates/cpp-cmake-project;
+        description = "A C++/CMake project template.";
+      };
+
+      nodejs-app = {
+        path = ./templates/nodejs-app;
+        description = "A Node.js application template.";
+      };
+
+      rust-app = {
+        path = ./templates/rust-app;
+        description = "A Rust application template.";
+      };
+
       defaultTemplate = self.templates.trivial;
     };
   };

--- a/templates/cpp-cmake-project/.gitignore
+++ b/templates/cpp-cmake-project/.gitignore
@@ -1,0 +1,9 @@
+# CMake build files
+build/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+compile_commands.json
+
+# Executable
+cpp-cmake-project

--- a/templates/cpp-cmake-project/CMakeLists.txt
+++ b/templates/cpp-cmake-project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(cpp-cmake-project)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(cpp-cmake-project main.cpp)

--- a/templates/cpp-cmake-project/flake.nix
+++ b/templates/cpp-cmake-project/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "A C++/CMake project template";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cmake
+            gcc
+            # Add other dependencies here
+          ];
+        };
+
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "cpp-cmake-project";
+          src = ./.;
+          nativeBuildInputs = with pkgs; [ cmake ];
+          # No install phase needed for a simple executable
+        };
+      });
+}

--- a/templates/cpp-cmake-project/main.cpp
+++ b/templates/cpp-cmake-project/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, Nix Flakes C++ CMake!" << std::endl;
+    return 0;
+}

--- a/templates/nodejs-app/.gitignore
+++ b/templates/nodejs-app/.gitignore
@@ -1,0 +1,12 @@
+# Node.js
+node_modules/
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+package-lock.json
+yarn.lock
+
+# Optional
+.idea/
+.vscode/
+*.env

--- a/templates/nodejs-app/flake.nix
+++ b/templates/nodejs-app/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "A Node.js application template";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        nodejs = pkgs.nodejs_20; # Or your preferred Node.js version
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            nodejs
+            pkgs.nodePackages.npm # or yarn, pnpm
+          ];
+        };
+
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "nodejs-app";
+          src = ./.;
+          buildInputs = [ nodejs pkgs.nodePackages.npm ];
+          buildPhase = ''
+            npm install
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp index.js $out/bin/nodejs-app
+            chmod +x $out/bin/nodejs-app
+          ''; # A more robust solution would use nodePackages.buildPackage
+        };
+      });
+}

--- a/templates/nodejs-app/index.js
+++ b/templates/nodejs-app/index.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+console.log("Hello, Nix Flakes Node.js!");
+
+// Example: Accessing arguments
+const args = process.argv.slice(2);
+if (args.length > 0) {
+  console.log("Arguments received:", args);
+}

--- a/templates/nodejs-app/package.json
+++ b/templates/nodejs-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nodejs-app",
+  "version": "1.0.0",
+  "description": "A simple Node.js application",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": ["nodejs", "nix", "flake"],
+  "author": "",
+  "license": "ISC"
+}

--- a/templates/rust-app/.gitignore
+++ b/templates/rust-app/.gitignore
@@ -1,0 +1,13 @@
+# Rust target directory
+/target
+
+# Rust Cargo lock file
+Cargo.lock
+
+# Editor configuration files
+.idea/
+.vscode/
+
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/templates/rust-app/Cargo.toml
+++ b/templates/rust-app/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-app"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/templates/rust-app/flake.nix
+++ b/templates/rust-app/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "A Rust application template";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.lib.${system};
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" ]; # for rust-analyzer
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustToolchain
+            rust-analyzer
+            # Add other dev dependencies here (e.g., lld, pkg-config)
+          ];
+          # Useful for rust-analyzer to find sysroot
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+        };
+
+        packages.default = craneLib.buildPackage {
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          # Additional arguments to crane can be provided here
+        };
+      });
+}

--- a/templates/rust-app/src/main.rs
+++ b/templates/rust-app/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, Nix Flakes Rust!");
+}


### PR DESCRIPTION
- Added Nix Flake templates for C++/CMake, Node.js, and Rust projects.
- Translated README.md to Korean (README.ko.md).
- Updated both English and Korean READMEs to include the new templates.